### PR TITLE
Remove `DataFrames.jl` dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ RecipesBase = "1.3.1"
 StatsAPI = "1.7"
 StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
 StatsModels = "0.7"
+Tables = "1.11"
 julia = "1.8.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "Mice"
 uuid = "d4678d24-b338-4f96-a2c8-a66549d61c16"
 authors = ["Tom Metherell <thomas.metherell.22@ucl.ac.uk> and contributors"]
-version = "0.0.1-DEV"
+version = "0.1.0-DEV"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedArrays = "86f7a689-2022-50b4-a561-43c23ac3c673"
@@ -16,10 +15,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "0.10"
-DataFrames = "1.6"
 Distributions = "0.25"
 NamedArrays = "0.10"
 RecipesBase = "1.3.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `Mice.jl` is a Julia package for multiple imputation using chained equations. It is heavily based on the R package [mice](https://cran.r-project.org/web/packages/mice/index.html) by Stef van Buuren and Karin Groothuis-Oudshoorn [[1]](#1).
 
-`Mice.jl`'s syntax is very similar to that of `mice` and it is intended to be used in conjunction with [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl).
+`Mice.jl`'s syntax is very similar to that of `mice` and it is intended to be used in conjunction with [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables, including [DataFrames](https://github.com/JuliaData/DataFrames.jl).
 
 ## Installation
 
@@ -29,11 +29,11 @@ Use the `mice()` function to perform multiple imputation on a DataFrame. The out
 
 #### Usage
 ```
-mice(df, m = 5, visitSequence = nothing, methods = nothing, predictorMatrix = nothing, iter = 10, progressReports = true, gcSchedule = 1.0, threads = true, ...)
+mice(data, m = 5, visitSequence = nothing, methods = nothing, predictorMatrix = nothing, iter = 10, progressReports = true, gcSchedule = 1.0, threads = true, ...)
 ```
 where:
 
-`df` is the DataFrame.
+`data` is the data table.
 
 `m` is the number of imputations.
 

--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -1,5 +1,5 @@
 # Imputation (`mice`)
-The main function of the package is `mice`, which takes a `DataFrame` as its input. It returns a multiply imputed dataset (`Mids`) object with the imputed values.
+The main function of the package is `mice`, which takes a `Tables.jl`-compatible table as its input. It returns a multiply imputed dataset (`Mids`) object with the imputed values.
 
 ```@docs
 Mids

--- a/docs/src/wrangling.md
+++ b/docs/src/wrangling.md
@@ -1,13 +1,10 @@
 # Data wrangling in Julia
 The procedures used for data wrangling in Julia are often very similar to those used in R. However, there are some fundamental differences between the languages that it is important to be aware of.
 
-## Better sources of information than this
-`Mice.jl` is intended to be used with `DataFrames.jl`. The [documentation](https://dataframes.juliadata.org/stable/man/missing/) for that package contains a comprehensive overview of using DataFrames.
-
 ## Data types
 Julia has a number of different data types. These include integers, floats, strings (known in R as "characters"), booleans and missing values.
 
-In a `DataFrame`, each column will have at least one type assigned to it. For example:
+In a `DataFrame` or other table, each column will have at least one type assigned to it. For example:
 
 ```julia
 using DataFrames
@@ -101,7 +98,7 @@ myData.col3
 
 ## Preparing your data for `mice`
 
-The `mice` function in `Mice.jl` requires a `DataFrame` as its first argument. Columns which contain values of the `missing` type will be imputed (unless you specify otherwise: more on this later).
+The `mice` function in `Mice.jl` requires a `Tables.jl`-compatible table as its first argument. Columns which contain values of the `missing` type will be imputed (unless you specify otherwise: more on this later).
 
 (Continuous) numeric variables don't require any special treatment. However, categorical variables are handled differently and may require some additional preparation.
 

--- a/src/with.jl
+++ b/src/with.jl
@@ -4,7 +4,7 @@
         imputation::Int
         )
 
-Produces a DataFrame with missings replaced with imputed values from a
+Produces a data table with missings replaced with imputed values from a
 multiply imputed dataset (`Mids`) object.
 
 The Mids object must be supplied first.
@@ -44,10 +44,10 @@ Summarises the outputs of all imputations in a multiply imputed dataset (`Mids`)
 The Mids object must be supplied first.
 
 The `action` argument is a string identifying what format the output should take.
-If specified as "long", the function will return a single DataFrame, containing
+If specified as "long", the function will return a single data table, containing
 the results of each imputation in succession with an identifier (`imp`).
 If specified as "list", the function will return a vector of individual
-DataFrames.
+data tables.
 """
 function complete(
     mids::Mids,
@@ -58,8 +58,11 @@ function complete(
     if !(action ∈ ["list", "long"])
         throw(ArgumentError("Action not defined. Valid arguments: \"list\", \"long\""))
     else
+        # Detect type of data object
+        T = typeof(mids.data)
+
         # Initialise output
-        data = Vector{DataFrame}(undef, mids.m)
+        data = Vector{T}(undef, mids.m)
 
         # For each imputation
         for i in 1:mids.m
@@ -79,9 +82,12 @@ function complete(
         if action == "list"
             return data
         elseif action == "long"
-            # Concatenate the DataFrames
+            # Concatenate the data tables
             for i in eachindex(data)
-                insertcols!(data[i], 1, :imp => i)
+                T = typeof(data[i])
+                rt = rowtable(data[i])
+                rt = [merge(r, (imp = i,)) for r in rt]
+                data[i] = T(rt)
             end
             return vcat(data...)
         end


### PR DESCRIPTION
Allowing `Mice.jl` to support any `Tables.jl` object, rather than just DataFrames (#11).