### PR TITLE
Improving `Tables.jl` compatibility & other changes

### DIFF
--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -3,10 +3,11 @@ Once you have a `Mids` object containing imputed data, you can use it to perform
 
 ## Inspecting imputed data
 
-If you just want to inspect the outcome of the imputation process, you can use the `complete` function to fill in the missing values in the original data frame.
+If you just want to inspect the outcome of the imputation process, you can use the `complete`/`listComplete` function to fill in the missing values in the original data frame.
 
 ```@docs
 complete
+listComplete
 ```
 
 ## Data analysis

--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -49,13 +49,7 @@ mice(myData, imputeWhere = myImputeWhere)
 ```
 
 ### Visit sequence
-The visit sequence is the order in which the variables are imputed. By default, `mice` sorts the variables in order of missingness (lowest to highest) via the function `makeMonotoneSequence`.
-
-```@docs
-makeMonotoneSequence
-```
-
-You can instead define your own visit sequence by creating a vector of variable names in your desired order and passing that to `mice`. For example:
+The visit sequence is the order in which the variables are imputed. By default, `mice` sorts the variables in order of missingness (lowest to highest) via the internal function `makeMonotoneSequence`. You can instead define your own visit sequence by creating a vector of variable names in your desired order and passing that to `mice`. For example:
 
 ```julia
 using DataFrames, Mice, Random
@@ -66,7 +60,7 @@ myData = DataFrame(
     :col3 => Vector{Union{Missing, String}}([missing, "2", missing, "4", missing])
 );
 
-makeMonotoneSequence(myData)
+Mice.makeMonotoneSequence(myData)
 # 3-element Vector{String}:
 # "col2"
 # "col1"

--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -95,6 +95,8 @@ mice(myData, visitSequence = myVisitSequence2)
 
 Assuming that the imputations converge normally, changing the visit sequence should not dramatically affect the output. However, it can be useful to change the visit sequence if you want to impute variables in a particular order for a specific reason. The sequence used by default in `Mice.jl` can make convergence faster in cases where the data follow a (near-)"monotone" missing data pattern [van_buuren_flexible_2018](@cite).
 
+You can leave variables out of the `visitSequence` to cause `mice()` to not impute them.
+
 ### Predictor matrix
 The predictor matrix defines which variables in the imputation model are used to predict which others. By default, every variable predicts every other variable, but there are a wide range of cases in which this is not desirable. For example, if your dataset includes an ID column, this is clearly useless for imputation and should be ignored.
 
@@ -154,7 +156,7 @@ mice(myData, predictorMatrix = myPredictorMatrix)
 ```
 
 ### Methods
-The imputation methods are the functions that are used to impute each variable. By default, `mice` uses predictive mean matching (`"pmm"`) for all variables (and currently PMM is the only method that `Mice.jl` supports). However, you can use the methods vector to specify any variables that should not be imputed.
+The imputation methods are the functions that are used to impute each variable. By default, `mice` uses predictive mean matching (`"pmm"`) for all variables (and currently PMM is the only method that `Mice.jl` supports).
 
 To create a default methods vector, use the function `makeMethods`.
 
@@ -183,7 +185,8 @@ myMethods = makeMethods(myData)
 # col2 | "pmm"
 # col3 | "pmm"
 
-# To stop the ID column from being imputed
+# To stop the ID column from being imputed (but you can also achieve this by leaving "id"
+# out of the visit sequence)
 myMethods["id"] = "";
 myMethods
 # 4-element Named Vector{String}

--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -9,6 +9,45 @@ mice
 ## Customising the imputation setup
 You can customise various aspects of the imputation setup by passing keyword arguments to `mice`. These are described above. You can also use some of the functions below to define objects that you can customise to alter how `mice` handles the imputation.
 
+### Locations to impute
+You can customise which data points are imputed by manipulating the `imputeWhere` argument. By default, this will specify that all missing data are to be imputed (using the function `findMissings()`).
+
+```@docs
+findMissings
+```
+
+You can over-impute existing data by setting the locations of non-missing data to `true` in the relevant vector in `imputeWhere`. For example, to impute all data points in the variable `col1` (even those that are not missing), you could do the following:
+
+```julia
+using DataFrames, Mice, Random
+
+myData = DataFrame(
+    :col1 => Vector{Union{Missing, Float64}}([1.0, missing, 3.0, missing, 5.0]),
+    :col2 => Vector{Union{Missing, Int64}}([1, 2, missing, 4, 5]),
+    :col3 => Vector{Union{Missing, String}}([missing, "2", missing, "4", missing])
+);
+
+myImputeWhere = findMissings(myData)
+# 3-element Named Vector{Vector{Bool}}
+# A    |
+# -----|--------------------
+# col1 | Bool[0, 1, 0, 1, 0]
+# col2 | Bool[0, 0, 1, 0, 0]
+# col3 | Bool[1, 0, 1, 0, 1]
+
+myImputeWhere["col1"][:] .= true;
+myImputeWhere
+# 3-element Named Vector{Vector{Bool}}
+# A    |
+# -----|--------------------
+# col1 | Bool[1, 1, 1, 1, 1]
+# col2 | Bool[0, 0, 1, 0, 0]
+# col3 | Bool[1, 0, 1, 0, 1]
+
+# Not run
+mice(myData, imputeWhere = myImputeWhere)
+```
+
 ### Visit sequence
 The visit sequence is the order in which the variables are imputed. By default, `mice` sorts the variables in order of missingness (lowest to highest) via the function `makeMonotoneSequence`.
 

--- a/src/Mice.jl
+++ b/src/Mice.jl
@@ -12,7 +12,7 @@ module Mice
     using StatsBase: CoefTable, PValue, sample, standardize, UnitRangeTransform, zscore
     import StatsModels: contrasts_matrix, termnames
     using StatsModels: AbstractContrasts, ModelFrame, ModelMatrix, setcontrasts!, term
-    using Tables: istable, rowtable
+    using Tables: columnnames, columns, columntable, getcolumn, istable
 
     """
         Mids

--- a/src/Mice.jl
+++ b/src/Mice.jl
@@ -23,6 +23,8 @@ module Mice
 
     The imputed data are stored as `imputations` (one column per imputation).
 
+    The locations at which data have been imputed are stored as `imputeWhere`.
+
     The number of imputations is stored as `m`.
 
     The imputation method for each variable is stored as `methods`.
@@ -40,6 +42,7 @@ module Mice
     struct Mids
         data
         imputations::Vector{Matrix}
+        imputeWhere::NamedVector{Vector{Bool}}
         m::Int
         methods::NamedArray
         predictorMatrix::NamedArray
@@ -49,9 +52,9 @@ module Mice
         varTraces::Vector{Matrix{Float64}}
         loggedEvents::Vector{String}
 
-        function Mids(data, imputations, m, methods, predictorMatrix, visitSequence, iter, meanTraces, varTraces, loggedEvents)
+        function Mids(data, imputations, imputeWhere, m, methods, predictorMatrix, visitSequence, iter, meanTraces, varTraces, loggedEvents)
             istable(data) || throw(ArgumentError("Data not provided as a Tables.jl table."))
-            new(data, imputations, m, methods, predictorMatrix, visitSequence, iter, meanTraces, varTraces, loggedEvents)
+            new(data, imputations, imputeWhere, m, methods, predictorMatrix, visitSequence, iter, meanTraces, varTraces, loggedEvents)
         end
     end
 
@@ -63,6 +66,7 @@ module Mice
         mice(
             data;
             m::Int = 5,
+            imputeWhere::Union{NamedVector{Vector{Bool}}, Nothing} = nothing,
             visitSequence::Union{Vector{String}, Nothing} = nothing,
             methods::Union{NamedVector{String}, Nothing} = nothing,
             predictorMatrix::Union{NamedMatrix{Bool}, Nothing} = nothing,
@@ -80,9 +84,13 @@ module Mice
 
     The number of imputations created is specified by `m`.
 
+    `imputeWhere` is a `NamedVector` of boolean vectors specifying where data are to be
+    imputed. The default is to impute all missing data.
+
     The variables will be imputed in the order specified by `visitSequence`. 
     The default is sorted by proportion of missing data in ascending order; 
     the order can be customised using a vector of variable names in the desired order.
+    Any column not to be imputed at all can be left out of the visit sequence.
 
     The imputation method for each variable is specified by the `NamedArray` `methods`. 
     The default is to use predictive mean matching (`pmm`) for all variables. 
@@ -112,6 +120,7 @@ module Mice
     function mice(
         data::T;
         m::Int = 5,
+        imputeWhere::Union{NamedVector{Vector{Bool}}, Nothing} = nothing,
         visitSequence::Union{Vector{String}, Nothing} = nothing,
         methods::Union{NamedVector{String}, Nothing} = nothing,
         predictorMatrix::Union{NamedMatrix{Bool}, Nothing} = nothing,
@@ -123,9 +132,19 @@ module Mice
         ) where {T}
         istable(T) || throw(ArgumentError("Data not provided as a Tables.jl table."))
 
-        # If no visit sequence specified: sort by proportion of missing data
+        # If locations to impute not specified: find locations of missing data
+        if imputeWhere === nothing
+            imputeWhere = findMissings(data)
+        end
+
+        # If nothing to be imputed: throw error
+        if sum(sum.(imputeWhere)) == 0
+            throw(ArgumentError("Provided dataset contains no missing data to be imputed."))
+        end
+
+        # If no visit sequence specified: sort by proportion of data to impute
         if visitSequence === nothing
-            visitSequence = makeMonotoneSequence(data)
+            visitSequence = makeMonotoneSequence(imputeWhere)
         end
 
         # If no methods specified: use pmm for all variables
@@ -139,7 +158,7 @@ module Mice
         end
 
         # Initialise imputations with random draws from the observed data
-        imputations = initialiseImputations(data, m, visitSequence, methods)
+        imputations = initialiseImputations(data, imputeWhere, m, visitSequence, methods)
 
         # Initialise mean and variance traces (for plotting)
         meanTraces = initialiseTraces(visitSequence, iter, m)
@@ -156,7 +175,7 @@ module Mice
         # For each iteration, for each variable
         for iterCounter in 1:iter, i in eachindex(visitSequence)
             # Run the Gibbs sampler
-            sampler!(imputations, meanTraces, varTraces, data, m, visitSequence, methods, predictorMatrix, iter, iterCounter, i, progressReports, loggedEvents, threads)
+            sampler!(imputations, meanTraces, varTraces, data, imputeWhere, m, visitSequence, methods, predictorMatrix, iter, iterCounter, i, progressReports, loggedEvents, threads)
             
             # If free RAM falls below specified threshold, invoke the garbage collector
             if Sys.free_memory()/Sys.total_memory() < gcSchedule
@@ -177,6 +196,7 @@ module Mice
         midsObj = Mids(
             data,
             imputations,
+            imputeWhere,
             m,
             methods,
             predictorMatrix,
@@ -219,6 +239,7 @@ module Mice
         # Grab existing parameters from the input Mids
         data = mids.data
         imputations = mids.imputations
+        imputeWhere = mids.imputeWhere
         m = mids.m
         methods = mids.methods
         predictorMatrix = mids.predictorMatrix
@@ -247,7 +268,7 @@ module Mice
         # For each new iteration, for each variable
         for iterCounter in prevIter+1:prevIter+iter, i in eachindex(visitSequence)
             # Run the Gibbs sampler
-            sampler!(imputations, meanTraces, varTraces, data, m, visitSequence, methods, predictorMatrix, prevIter+iter, iterCounter, i, progressReports, loggedEvents, threads)
+            sampler!(imputations, meanTraces, varTraces, data, imputeWhere, m, visitSequence, methods, predictorMatrix, prevIter+iter, iterCounter, i, progressReports, loggedEvents, threads)
             
             # If free RAM falls below specified threshold, invoke the garbage collector
             if Sys.free_memory()/Sys.total_memory() < gcSchedule
@@ -264,6 +285,7 @@ module Mice
         midsObj = Mids(
             data,
             imputations,
+            imputeWhere,
             m,
             methods,
             predictorMatrix,
@@ -347,6 +369,11 @@ module Mice
             throw(ArgumentError("Cannot bind these Mids objects: they appear to result from different datasets."))
         end
 
+        imputeWhere = mids1.imputeWhere
+        if imputeWhere !== mids2.imputeWhere
+            throw(ArgumentError("Cannot bind these Mids objects: the locations of imputed data are different."))
+        end
+
         methods = mids1.methods
         if methods != mids2.methods
             throw(ArgumentError("Cannot bind these Mids objects: the imputation methods are different."))
@@ -394,6 +421,7 @@ module Mice
         midsObj = Mids(
             data,
             imputations,
+            imputeWhere,
             m,
             methods,
             predictorMatrix,

--- a/src/micehelperfunctions.jl
+++ b/src/micehelperfunctions.jl
@@ -732,4 +732,4 @@ function matchIndex(
     return indices
 end
 
-export makeMethods, makePredictorMatrix
+export findMissings, makeMethods, makePredictorMatrix

--- a/src/micehelperfunctions.jl
+++ b/src/micehelperfunctions.jl
@@ -24,12 +24,12 @@ It is the default visit sequence for the `mice()` function.
 function makeMonotoneSequence(imputeWhere::NamedVector{Vector{Bool}})
     missingness = sum.(imputeWhere)
 
-    numberOfIncompletes = sum(sum.(imputeWhere) .!= 0)
+    numberOfCompletes = sum(sum.(imputeWhere) .== 0)
 
     missingness = sort(missingness)
 
     # Sort the data frame names vector by missingness
-    visitSequence = names(missingness)[1][1:numberOfIncompletes]
+    visitSequence = names(missingness)[1][numberOfCompletes+1:end]
 
     return visitSequence
 end

--- a/src/micehelperfunctions.jl
+++ b/src/micehelperfunctions.jl
@@ -290,7 +290,7 @@ function sampler!(
                             diff = origNCol - size(X, 2)
                             push!(loggedEvents, "Iteration $iterCounter, variable $yVar, imputation $j: $diff (dummy) predictors were dropped because of high multicollinearity.")
                         end
-                        imputedData = pmmImpute!(y, X, whereY, 5, 1e-5, yVar, iterCounter, j, tempLog)
+                        imputedData = pmmImpute!(y, X, whereY, 5, 1e-5, yVar, iterCounter, j, loggedEvents)
                     else
                         push!(loggedEvents, "Iteration $iterCounter, variable $yVar, imputation $j: imputation skipped - all predictors dropped because of high multicollinearity.")
                         imputedData = imputations[i][:, j]

--- a/src/micehelperfunctions.jl
+++ b/src/micehelperfunctions.jl
@@ -14,13 +14,6 @@ function findMissings(data::T) where{T}
     return imputeWhere
 end
 
-"""
-    makeMonotoneSequence(imputeWhere::NamedVector{Vector{Bool}})
-
-Returns a vector of the column names in a data table in ascending order of missingness.
-This facilitates convergence in cases where missingness follows a "monotone" pattern.
-It is the default visit sequence for the `mice()` function.
-"""
 function makeMonotoneSequence(imputeWhere::NamedVector{Vector{Bool}})
     missingness = sum.(imputeWhere)
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -20,7 +20,6 @@ The function will work on any `Mira` object containing model outputs which are
 receptive to the `coef`, `stderror` and `nobs` functions from StatsAPI.jl.
 """
 function pool(mira::Mira)
-
     # Grab coefficients and standard errors from each analysis
     coefs = transpose(reduce(hcat, coef.(mira.analyses)))
     stderrors = transpose(reduce(hcat, stderror.(mira.analyses)))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,9 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 Mice = "d4678d24-b338-4f96-a2c8-a66549d61c16"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ using CSV, DataFrames, GLM, Mice, Test
 
     imputedData = mice(data, m = 20, iter = 15, methods = theMethods, predictorMatrix = predictorMatrix, threads = false, gcSchedule = 0.3, progressReports = false)
 
-    @test length(imputedData.loggedEvents) == 120
+    @test length(imputedData.loggedEvents) == 0
 
     imputedDataLong = complete(imputedData, "long")
 


### PR DESCRIPTION
Significant changes introduced to allow `Mice.jl` to be fully compatible with `Tables.jl` tables (#11). Also:
- new argument `imputeWhere` introduced to allow the locations of data to be imputed to be specified;
- reductions in latency where there is nothing to impute (#8);
- tests made more expansive and quicker to run and
- "long" `complete()` function withdrawn, and "list" functionality replaced with `listComplete()`.