### PR TITLE
Adding methods `mean`, `norm` and `sample`

### DIFF
--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -6,6 +6,7 @@ System info: Single-threaded execution, Intel® Core™ i7-12700H 2.30GHz CPU, 3
 
 R: version 4.3.1 running `mice` version 3.16.0.
 Julia: version 1.9.2 running `Mice.jl` version 0.1.0.
+Both used predictive mean matching for all variables that were to be imputed.
 
 ### Imputation (`mice`)
 

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -4,14 +4,14 @@
 `Mice.jl` is not registered yet. To install the current pre-release version:
 
 ```
-] add https://github.com/tom-metherell/Mice.jl.git#v0.1.0
+] add https://github.com/tom-metherell/Mice.jl.git#v0.1.1
 ```
 
 or
 
 ```julia
 using Pkg
-Pkg.add(url = "https://github.com/tom-metherell/Mice.jl.git", rev = "v0.1.0")
+Pkg.add(url = "https://github.com/tom-metherell/Mice.jl.git", rev = "v0.1.1")
 ```
 
 ## Usage

--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -150,7 +150,12 @@ mice(myData, predictorMatrix = myPredictorMatrix)
 ```
 
 ### Methods
-The imputation methods are the functions that are used to impute each variable. By default, `mice` uses predictive mean matching (`"pmm"`) for all variables (and currently PMM is the only method that `Mice.jl` supports).
+The imputation methods are the functions that are used to impute each variable. By default, `mice` uses predictive mean matching (`"pmm"`) for all variables. Currently `Mice.jl` supports the following methods:
+
+| Method | Description | Variable type |
+| ------ | ----------- | ------------- |
+| `pmm` | Predictive mean matching | Any |
+| `norm` | Bayesian linear regression | Numeric (float) |
 
 To create a default methods vector, use the function `makeMethods`.
 
@@ -190,6 +195,17 @@ myMethods
 # col1 | "pmm"
 # col2 | "pmm"
 # col3 | "pmm"
+
+# To use Bayesian linear regression to impute col1
+myMethods["col1"] = "norm";
+myMethods
+# 4-element Named Vector{String}
+# A    |
+# -----|-------
+# id   |     ""
+# col1 | "norm"
+# col2 |  "pmm"
+# col3 |  "pmm"
 
 Random.seed!(1234); # Set random seed for reproducibility
 

--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -155,7 +155,11 @@ The imputation methods are the functions that are used to impute each variable. 
 | Method | Description | Variable type |
 | ------ | ----------- | ------------- |
 | `pmm` | Predictive mean matching | Any |
+| `sample` | Random sample from observed values | Any |
+| `mean` | Mean of observed values | Numeric (float) |
 | `norm` | Bayesian linear regression | Numeric (float) |
+
+The `mean` and `sample` methods should not generally be used.
 
 To create a default methods vector, use the function `makeMethods`.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,6 @@
 
 `Mice.jl` is the Julia equivalent of the R package `mice` by Stef van Buuren, Karin Groothuis-Oudshoorn and collaborators [van_buuren_mice_2011](@cite). It allows you to impute missing values in a dataset using multiple imputation by chained equations (MICE).
 
-Currently, only predictive mean matching (PMM) is supported as a method. `Mice.jl` also currently does not support hybrid imputation models.
+Currently, only predictive mean matching (PMM) and Bayesian linear regression are supported as methods. `Mice.jl` also currently does not support hybrid imputation models.
 
 If you want to learn more about multiple imputation, this is not the guide for you. Instead, I recommend consulting ["Flexible Imputation of Missing Data"](https://stefvanbuuren.name/fimd/) by Stef van Buuren (ed.) [van_buuren_flexible_2018](@cite).

--- a/src/Mice.jl
+++ b/src/Mice.jl
@@ -1,7 +1,7 @@
 module Mice
     # Dependencies
     using CategoricalArrays: CategoricalArray, levels
-    using Distributions: cdf, Chisq, Normal, TDist
+    using Distributions: ccdf, Chisq, FDist, Normal, TDist
     using LinearAlgebra: cholesky, Diagonal, diagm, eigen, inv, qr, rank, svd
     using NamedArrays: NamedArray, NamedMatrix, NamedVector, setnames!
     using Printf: @printf
@@ -93,8 +93,7 @@ module Mice
     Any column not to be imputed at all can be left out of the visit sequence.
 
     The imputation method for each variable is specified by the `NamedArray` `methods`. 
-    The default is to use predictive mean matching (`pmm`) for all variables. 
-    Currently only `pmm` is supported. 
+    The default is to use predictive mean matching (`pmm`) for all variables.
     Any variable not to be imputed can be marked as such using an empty string ("").
 
     The predictor matrix is specified by the `NamedArray` `predictorMatrix`. 

--- a/src/Mice.jl
+++ b/src/Mice.jl
@@ -1,6 +1,6 @@
 module Mice
     # Dependencies
-    using CategoricalArrays: CategoricalArray, levels
+    using CategoricalArrays: CategoricalArray, CategoricalValue, levels
     using Distributions: ccdf, Chisq, FDist, Normal, TDist
     using LinearAlgebra: cholesky, Diagonal, diagm, eigen, inv, qr, rank, svd
     using NamedArrays: NamedArray, NamedMatrix, NamedVector, setnames!


### PR DESCRIPTION
Adding three new (simple) imputation methods:
`mean` - simply using the mean of the observed data;
`norm` - using Bayesian linear regression and
`sample` - using a random sample of the observed data.

`mean` and `sample` are not intended for routine use but are included because of their inclusion in the R package.